### PR TITLE
fix non-ascii character in docstring for python 2

### DIFF
--- a/mcfit/cosmology.py
+++ b/mcfit/cosmology.py
@@ -64,12 +64,12 @@ class DoubleSphericalBessel(mcfit):
 
 
 class TophatVar(mcfit):
-    """Variance in a top-hat window
+    r"""Variance in a top-hat window
 
     Examples
     --------
-    To compute σ₈ of a linear power spectrum :math:`P(k)`, with k in unit of
-    :math:`h/\mathrm{Mpc}` and P in unit of :math:`\mathrm{Mpc}^3/h^3`
+    To compute :math:`\sigma_8` of a linear power spectrum :math:`P(k)`, with
+    k in unit of :math:`h/\mathrm{Mpc}` and P in unit of :math:`\mathrm{Mpc}^3/h^3`
     >>> R, var = TophatVar(k)(P)
     >>> from scipy.interpolate import CubicSpline
     >>> varR = CubicSpline(R, var)


### PR DESCRIPTION
Currently the code cannot be imported with python 2 due to a non-ASCII character in one of the docstrings in the cosmology module.